### PR TITLE
Fix inconsistent data type issue for port, sub_type and KeywordType

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/exileed/uptimerobotapi
+module github.com/bigdatasourav/uptimerobotapi
 
 go 1.15
 

--- a/m_window.go
+++ b/m_window.go
@@ -68,10 +68,11 @@ type MWindow struct {
 	User         int    `json:"user"`
 	Type         int    `json:"type"`
 	FriendlyName string `json:"friendly_name"`
-	StartTime    string `json:"start_time"`
-	Duration     int    `json:"duration"`
-	Value        string `json:"value"`
-	Status       int    `json:"status"`
+	// StartTime comes from API as a string value with a format like “18:20.”
+	StartTime string `json:"start_time"`
+	Duration  int    `json:"duration"`
+	Value     string `json:"value"`
+	Status    int    `json:"status"`
 }
 
 // GetMWindows Get https://uptimerobot.com/#getMWindows

--- a/m_window.go
+++ b/m_window.go
@@ -14,7 +14,8 @@ type GetMWindowParams struct {
 	Value        string `url:"value"`
 	StartTime    string `url:"start_time"`
 	Duration     string `url:"duration"`
-	Offset       int    `url:"offset,omitempty"`
+	Offset        int   `url:"offset,omitempty"`
+	Limit        *int   `url:"limit,omitempty"`
 }
 
 type NewMWindowParams struct {

--- a/m_window.go
+++ b/m_window.go
@@ -14,6 +14,7 @@ type GetMWindowParams struct {
 	Value        string `url:"value"`
 	StartTime    string `url:"start_time"`
 	Duration     string `url:"duration"`
+	Offset       int    `url:"offset,omitempty"`
 }
 
 type NewMWindowParams struct {

--- a/m_window.go
+++ b/m_window.go
@@ -68,7 +68,7 @@ type MWindow struct {
 	User         int    `json:"user"`
 	Type         int    `json:"type"`
 	FriendlyName string `json:"friendly_name"`
-	StartTime    int    `json:"start_time"`
+	StartTime    string `json:"start_time"`
 	Duration     int    `json:"duration"`
 	Value        string `json:"value"`
 	Status       int    `json:"status"`

--- a/m_window_test.go
+++ b/m_window_test.go
@@ -43,7 +43,7 @@ func TestGetMWindows(t *testing.T) {
 
 	require.NoError(t, err)
 
-	mwindows := []MWindow{{Id: 111, User: 1, Type: 1, FriendlyName: "Once Backup", StartTime: 1461024000, Duration: 12, Value: "", Status: 1}}
+	mwindows := []MWindow{{Id: 111, User: 1, Type: 1, FriendlyName: "Once Backup", StartTime: "18:20", Duration: 12, Value: "", Status: 1}}
 
 	want := &MWindowsResp{Stat: StatOk, Pagination: Pagination{Total: 1, Limit: 10, Offset: 0}, MWindows: mwindows}
 

--- a/monitors.go
+++ b/monitors.go
@@ -110,7 +110,7 @@ type Monitor struct {
 	Url             string                 `json:"url"`
 	Type            int                    `json:"type"`
 	SubType         string                 `json:"sub_type"`
-	Port            string                 `json:"port"`
+	Port            int                    `json:"port"`
 	KeywordType     *int                   `json:"keyword_type"`
 	KeywordCaseType *int                   `json:"keyword_case_type"`
 	KeywordValue    string                 `json:"keyword_value"`

--- a/monitors.go
+++ b/monitors.go
@@ -105,13 +105,15 @@ type AlertContactMonitor struct {
 }
 
 type Monitor struct {
-	Id              int                    `json:"id"`
-	FriendlyName    string                 `json:"friendly_name"`
-	Url             string                 `json:"url"`
-	Type            int                    `json:"type"`
-	SubType         string                 `json:"sub_type"`
-	Port            int                    `json:"port"`
-	KeywordType     *int                   `json:"keyword_type"`
+	Id           int    `json:"id"`
+	FriendlyName string `json:"friendly_name"`
+	Url          string `json:"url"`
+	Type         int    `json:"type"`
+	// sub_type, port and keyword_type are returned as either an integer or an empty string,
+	// which Go doesn't allow: https://github.com/golang/go/issues/22182
+	SubType         interface{}            `json:"sub_type"`
+	Port            interface{}            `json:"port"`
+	KeywordType     interface{}            `json:"keyword_type"`
 	KeywordCaseType *int                   `json:"keyword_case_type"`
 	KeywordValue    string                 `json:"keyword_value"`
 	HttpUsername    string                 `json:"http_username"`


### PR DESCRIPTION
sub_type, port and keyword_type are returned as either an integer or an empty string.
At the time of Unmarshal, it throws errors like below -
Error: json: cannot unmarshal string into Go struct field Monitor.monitors.port of type int